### PR TITLE
Pass required callback function for i2c write

### DIFF
--- a/src/pn532_i2c.js
+++ b/src/pn532_i2c.js
@@ -24,7 +24,7 @@ class PN532_I2C extends EventEmitter {
     }
 
     write(buffer) {
-        this.wire.write(buffer);
+        this.wire.write(buffer, () => {});
     }
 }
 


### PR DESCRIPTION
`i2c` library requires a callback function when calling the `write` function.

Passing a `noop` function to avoid the following error when initializing the i2c reader:

```
.../node_modules/i2c/lib/i2c.coffee:88
          return callback(err);
                 ^

TypeError: callback is not a function
  at Immediate.<anonymous> (.../node_modules/i2c/lib/i2c.coffee:54:9)
  at runCallback (timers.js:672:20)
  at tryOnImmediate (timers.js:645:5)
  at processImmediate [as _immediateCallback] (timers.js:617:5)
```