### PR TITLE
update examples to current serialport module

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ and `npm install serialport` or `npm install i2c`
 #### UART (using [node-serialport](https://github.com/voodootikigod/node-serialport))
 ```js
 var pn532 = require('pn532');
-var SerialPort = require('serialport').SerialPort;
+var SerialPort = require('serialport');
 
-var serialPort = new SerialPort('/dev/tty.usbserial-AFWR836M', { baudrate: 115200 });
+var serialPort = new SerialPort('/dev/tty.usbserial-AFWR836M', { baudRate: 115200 });
 var rfid = new pn532.PN532(serialPort);
 ```
 
@@ -40,7 +40,7 @@ var rfid = new pn532.PN532(wire);
 ```js
 rfid.on('ready', function() {
     rfid.scanTag().then(function(tag) {
-        console.log('tag:', tag.uid);
+        if (tag) console.log('tag:', tag.uid);
     });
 });
 ```
@@ -50,7 +50,7 @@ rfid.on('ready', function() {
 rfid.on('ready', function() {
     console.log('Listening for a tag scan...');
     rfid.on('tag', function(tag) {
-        console.log('tag:', tag.uid);
+        if (tag) console.log('tag:', tag.uid);
     });
 });
 ```

--- a/examples/card_scan.js
+++ b/examples/card_scan.js
@@ -1,7 +1,7 @@
 var pn532 = require('../src/pn532');
-var SerialPort = require('serialport').SerialPort;
+var SerialPort = require('serialport');
 
-var serialPort = new SerialPort('/dev/tty.usbserial-AFWR836M', { baudrate: 115200 });
+var serialPort = new SerialPort('/dev/tty.usbserial-AFWR836M', { baudRate: 115200 });
 var rfid = new pn532.PN532(serialPort);
 
 console.log('Waiting for rfid ready event...');

--- a/examples/mifare_classic.js
+++ b/examples/mifare_classic.js
@@ -1,7 +1,7 @@
 var pn532 = require('../src/pn532');
-var SerialPort = require('serialport').SerialPort;
+var SerialPort = require('serialport');
 
-var serialPort = new SerialPort('/dev/tty.usbserial-AFWR836M', { baudrate: 115200 });
+var serialPort = new SerialPort('/dev/tty.usbserial-AFWR836M', { baudRate: 115200 });
 var rfid = new pn532.PN532(serialPort, { pollInterval: 3000 });
 var ndef = require('ndef');
 

--- a/examples/read_data.js
+++ b/examples/read_data.js
@@ -1,7 +1,7 @@
 var pn532 = require('../src/pn532');
-var SerialPort = require('serialport').SerialPort;
+var SerialPort = require('serialport');
 
-var serialPort = new SerialPort('/dev/tty.usbserial-AFWR836M', { baudrate: 115200 });
+var serialPort = new SerialPort('/dev/tty.usbserial-AFWR836M', { baudRate: 115200 });
 var rfid = new pn532.PN532(serialPort);
 var ndef = require('ndef');
 

--- a/examples/write_data.js
+++ b/examples/write_data.js
@@ -1,7 +1,7 @@
 var pn532 = require('../src/pn532');
-var SerialPort = require('serialport').SerialPort;
+var SerialPort = require('serialport');
 
-var serialPort = new SerialPort('/dev/tty.usbserial-AFWR836M', { baudrate: 115200 });
+var serialPort = new SerialPort('/dev/tty.usbserial-AFWR836M', { baudRate: 115200 });
 var rfid = new pn532.PN532(serialPort);
 var ndef = require('ndef');
 


### PR DESCRIPTION
serialport has changed its api. therefore the examples and the code in the readme does not work anymore. see also: https://github.com/serialport/node-serialport/issues/1412

